### PR TITLE
feat: add scan type to event

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DataWedge.addListener('scan', event => {
 * [`disableScanner()`](#disablescanner)
 * [`startScanning()`](#startscanning)
 * [`stopScanning()`](#stopscanning)
-* [`addListener('scan', ...)`](#addlistenerscan-)
+* [`addListener('scan', ...)`](#addlistenerscan)
 * [`__registerReceiver()`](#__registerreceiver)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -199,9 +199,10 @@ THIS METHOD IS FOR INTERNAL USE ONLY
 
 #### ScanListenerEvent
 
-| Prop       | Type                | Description     | Since |
-| ---------- | ------------------- | --------------- | ----- |
-| **`data`** | <code>string</code> | Data of barcode | 0.1.0 |
+| Prop       | Type                        | Description     | Since |
+| ---------- | --------------------------- | --------------- | ----- |
+| **`data`** | <code>string</code>         | Data of barcode | 0.1.0 |
+| **`type`** | <code>string \| null</code> | Type of barcode |       |
 
 
 ### Type Aliases

--- a/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedgePlugin.java
+++ b/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedgePlugin.java
@@ -115,9 +115,11 @@ public class DataWedgePlugin extends Plugin {
 
             try {
                 String data = intent.getStringExtra("com.symbol.datawedge.data_string");
+                String type = intent.getStringExtra("com.symbol.datawedge.label_type");
 
                 JSObject ret = new JSObject();
                 ret.put("data", data);
+                ret.put("type", type);
 
                 notifyListeners("scan", ret);
             } catch(Exception e) {}

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,6 +7,11 @@ export interface ScanListenerEvent {
    * @since 0.1.0
    */
   data: string;
+
+  /**
+   * Type of barcode
+   */
+  type: string | null;
 }
 
 export type ScanListener = (state: ScanListenerEvent) => void;


### PR DESCRIPTION
Added the scan type to the event data. Can be null on multiscan.

This is useful if you want to handle different scan types differently.

Feedback appreciated