### PR TITLE
Feat: send and receive DataWedge broadcast intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ DataWedge.addListener('scan', event => {
 * [`disableScanner()`](#disablescanner)
 * [`startScanning()`](#startscanning)
 * [`stopScanning()`](#stopscanning)
-* [`addListener('scan', ...)`](#addlistenerscan)
+* [`registerBroadcastReceiver(...)`](#registerbroadcastreceiver)
+* [`sendBroadcastWithExtras(...)`](#sendbroadcastwithextras)
+* [`addListener('scan' | 'broadcast', ...)`](#addlistenerscan--broadcast)
+* [`removeAllListeners()`](#removealllisteners)
 * [`__registerReceiver()`](#__registerreceiver)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -154,24 +157,71 @@ Broadcasts intent action with `.SOFT_SCAN_TRIGGER` extra set to `STOP_SCANNING`
 --------------------
 
 
-### addListener('scan', ...)
+### registerBroadcastReceiver(...)
 
 ```typescript
-addListener(eventName: 'scan', listenerFunc: ScanListener) => Promise<PluginListenerHandle> & PluginListenerHandle
+registerBroadcastReceiver(filter: BroadcastReceiverFilter) => Promise<void>
+```
+
+Register broadcast receiver
+
+| Param        | Type                                                                        |
+| ------------ | --------------------------------------------------------------------------- |
+| **`filter`** | <code><a href="#broadcastreceiverfilter">BroadcastReceiverFilter</a></code> |
+
+**Since:** 0.3.0
+
+--------------------
+
+
+### sendBroadcastWithExtras(...)
+
+```typescript
+sendBroadcastWithExtras(intent: BroadcastIntent) => Promise<void>
+```
+
+Send broadcast with extras
+
+| Param        | Type                                                        |
+| ------------ | ----------------------------------------------------------- |
+| **`intent`** | <code><a href="#broadcastintent">BroadcastIntent</a></code> |
+
+**Since:** 0.3.0
+
+--------------------
+
+
+### addListener('scan' | 'broadcast', ...)
+
+```typescript
+addListener(eventName: 'scan' | 'broadcast', listenerFunc: ScanListener | BroadcastListener) => Promise<PluginListenerHandle> & PluginListenerHandle
 ```
 
 Listen for successful barcode readings
 
 ***Notice:*** Requires intent action to be set to `com.capacitor.datawedge.RESULT_ACTION` in current DataWedge profile (it may change in the future)
 
-| Param              | Type                                                  |
-| ------------------ | ----------------------------------------------------- |
-| **`eventName`**    | <code>'scan'</code>                                   |
-| **`listenerFunc`** | <code><a href="#scanlistener">ScanListener</a></code> |
+| Param              | Type                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'scan' \| 'broadcast'</code>                                                                          |
+| **`listenerFunc`** | <code><a href="#scanlistener">ScanListener</a> \| <a href="#broadcastlistener">BroadcastListener</a></code> |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt; & <a href="#pluginlistenerhandle">PluginListenerHandle</a></code>
 
 **Since:** 0.1.0
+
+--------------------
+
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners() => Promise<void>
+```
+
+Remove all listeners
+
+**Since:** 0.3.0
 
 --------------------
 
@@ -182,7 +232,7 @@ Listen for successful barcode readings
 __registerReceiver() => Promise<void>
 ```
 
-Internal method to register intent broadcast receiver 
+Internal method to register intent broadcast receiver
 
 THIS METHOD IS FOR INTERNAL USE ONLY
 
@@ -212,9 +262,29 @@ THIS METHOD IS FOR INTERNAL USE ONLY
 ### Type Aliases
 
 
+#### BroadcastReceiverFilter
+
+<code>{ filterActions: string[]; filterCategories: string[]; }</code>
+
+
+#### BroadcastIntent
+
+<code>{ action: string; extras: <a href="#jsonobject">JsonObject</a>; }</code>
+
+
+#### JsonObject
+
+<code>{ [key: string]: | string | number | boolean | <a href="#jsonobject">JsonObject</a> | string[] | number[] | boolean[] | JsonObject[]; }</code>
+
+
 #### ScanListener
 
 <code>(state: <a href="#scanlistenerevent">ScanListenerEvent</a>): void</code>
+
+
+#### BroadcastListener
+
+<code>(state: <a href="#jsonobject">JsonObject</a>): void</code>
 
 </docgen-api>
 

--- a/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedge.java
+++ b/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedge.java
@@ -1,7 +1,14 @@
 package com.jkbz.capacitor.datawedge;
 
+import android.os.Bundle;
 import android.util.Log;
 import android.content.Intent;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
 
 public class DataWedge {
     public static final String DATAWEDGE_PACKAGE = "com.symbol.datawedge.api";
@@ -53,6 +60,60 @@ public class DataWedge {
         intent.putExtra("com.symbol.datawedge.api.SOFT_SCAN_TRIGGER", "STOP_SCANNING");
 
         return intent;
+    }
+
+    public static Bundle toBundle(JSObject json) throws JSONException {
+        Bundle bundle = new Bundle();
+        Iterator<String> keys = json.keys();
+
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value = json.get(key);
+
+            if (value instanceof Boolean) {
+                bundle.putBoolean(key, (Boolean) value);
+            } else if (value instanceof Integer) {
+                bundle.putInt(key, (Integer) value);
+            } else if (value instanceof Long) {
+                bundle.putLong(key, (Long) value);
+            } else if (value instanceof Double) {
+                bundle.putDouble(key, (Double) value);
+            } else if (value instanceof String) {
+                bundle.putString(key, (String) value);
+            } else if (value instanceof JSObject) {
+                bundle.putBundle(key, toBundle((JSObject) value));
+            } else if (value instanceof JSArray) {
+                bundle.putString(key, value.toString());
+            }
+            // Handle other data types as needed
+        }
+
+        return bundle;
+    }
+    public static JSObject bundleToJSObject(Bundle bundle) {
+        JSObject jsObject = new JSObject();
+
+        for (String key : bundle.keySet()) {
+            Object value = bundle.get(key);
+
+            if (value instanceof Boolean) {
+                jsObject.put(key, (Boolean) value);
+            } else if (value instanceof Integer) {
+                jsObject.put(key, (Integer) value);
+            } else if (value instanceof Long) {
+                jsObject.put(key, (Long) value);
+            } else if (value instanceof Double) {
+                jsObject.put(key, (Double) value);
+            } else if (value instanceof String) {
+                jsObject.put(key, (String) value);
+            } else if (value instanceof Bundle) {
+                jsObject.put(key, bundleToJSObject((Bundle) value));
+            } else {
+                jsObject.put(key, value != null ? value.toString() : JSONObject.NULL);
+            }
+        }
+
+        return jsObject;
     }
 }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,7 +3,7 @@ import type { PluginListenerHandle } from '@capacitor/core';
 export interface ScanListenerEvent {
   /**
    * Data of barcode
-   * 
+   *
    * @since 0.1.0
    */
   data: string;
@@ -17,14 +17,35 @@ export interface ScanListenerEvent {
 }
 
 export type ScanListener = (state: ScanListenerEvent) => void;
+export type BroadcastListener = (state: JsonObject) => void;
+export type BroadcastReceiverFilter = {
+  filterActions: string[];
+  filterCategories: string[];
+};
+
+export type JsonObject = {
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | JsonObject
+    | string[]
+    | number[]
+    | boolean[]
+    | JsonObject[];
+};
+
+export type BroadcastIntent = {
+  action: string;
+  extras: JsonObject;
+}
 
 export interface DataWedgePlugin {
-
   /**
    * Enables DataWedge
    *
-   * Broadcasts intent action with `.ENABLE_DATAWEDGE` extra set to `true` 
-   * 
+   * Broadcasts intent action with `.ENABLE_DATAWEDGE` extra set to `true`
+   *
    * @since 0.0.3
    */
   enable(): Promise<void>;
@@ -33,7 +54,7 @@ export interface DataWedgePlugin {
    * Disables DataWedge
    *
    * Broadcasts intent action with `.ENABLE_DATAWEDGE` extra set to `false`
-   * 
+   *
    * @since 0.0.3
    */
   disable(): Promise<void>;
@@ -42,7 +63,7 @@ export interface DataWedgePlugin {
    * Enables physical scanner
    *
    * Broadcasts intent action with `.SCANNER_INPUT_PLUGIN` extra set to `ENABLE_PLUGIN`
-   * 
+   *
    * @since 0.0.3
    */
   enableScanner(): Promise<void>;
@@ -51,7 +72,7 @@ export interface DataWedgePlugin {
    * Disables physical scanner
    *
    * Broadcasts intent action with `.SCANNER_INPUT_PLUGIN` extra set to `DISABLE_PLUGIN`
-   * 
+   *
    * @since 0.0.3
    */
   disableScanner(): Promise<void>;
@@ -75,22 +96,41 @@ export interface DataWedgePlugin {
   stopScanning(): Promise<void>;
 
   /**
-  * Listen for successful barcode readings
-  * 
-  * ***Notice:*** Requires intent action to be set to `com.capacitor.datawedge.RESULT_ACTION` in current DataWedge profile (it may change in the future)
-  *
-  * @since 0.1.0
-  */
+   * Register broadcast receiver
+   *
+   * @since 0.3.0
+   */
+  registerBroadcastReceiver(filter: BroadcastReceiverFilter): Promise<void>;
+
+  /**
+   * Send broadcast with extras
+   *
+   * @since 0.3.0
+   */
+  sendBroadcastWithExtras(intent:BroadcastIntent): Promise<void>;
+  /**
+   * Listen for successful barcode readings
+   *
+   * ***Notice:*** Requires intent action to be set to `com.capacitor.datawedge.RESULT_ACTION` in current DataWedge profile (it may change in the future)
+   *
+   * @since 0.1.0
+   */
   addListener(
-    eventName: 'scan',
-    listenerFunc: ScanListener
+    eventName: 'scan' | 'broadcast',
+    listenerFunc: ScanListener | BroadcastListener,
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
-   * Internal method to register intent broadcast receiver 
+   * Remove all listeners
+   *
+   * @since 0.3.0
+   */
+  removeAllListeners(): Promise<void>;
+  /**
+   * Internal method to register intent broadcast receiver
    *
    * THIS METHOD IS FOR INTERNAL USE ONLY
-   * 
+   *
    * @since 0.1.3
    * @private
    */

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,6 +27,13 @@ export class DataWedgeWeb extends WebPlugin implements DataWedgePlugin {
     throw 'DataWedge is not supported on web';
   }
 
+  registerBroadcastReceiver(): Promise<void> {
+    throw 'DataWedge is not supported on web';
+  }
+
+  sendBroadcastWithExtras(): Promise<void> {
+    throw 'DataWedge is not supported on web';
+  }
   async __registerReceiver(): Promise<void> {
     // no-op
   }


### PR DESCRIPTION
I don't have an idea about how the contribution should be done since this is my first time tbh, I'll be more then happy if you guide me ^^ 

changes description : 
2 methods are added to send and receive broadcast intents, they will give the chance to integrate DataWedge intent  commands ( create/update profile , get DataWedge version , custom broadcast intent filters etc ) 

* registerBroadcastReceiver : 
    gives the ability to register custom broadcast receivers , example : 
```javascript
    const filterActions = [
      "com.symbol.datawedge.api.RESULT_ACTION",
      "com.example.ACTION"
    ]
    const filterCategories = ["android.intent.category.DEFAULT"]
    const filter = { filterActions, filterCategories }
    await DataWedge.registerBroadcastReceiver(filter)
```
* sendBroadcastWithExtras : 
    gives the ability to send broadcast intents with extras, with it we can implement any DataWedge api commands, 
      example : 
```javascript
await DataWedge.sendBroadcastWithExtras({
      action: "com.symbol.datawedge.api.ACTION",
      extras: {
        "com.symbol.datawedge.api.SET_CONFIG": {
          PROFILE_NAME: "Example",
          PROFILE_ENABLED: "true",
          CONFIG_MODE: "UPDATE",
          PLUGIN_CONFIG: {
            PLUGIN_NAME: "INTENT",
            RESET_CONFIG: "true",
            PARAM_LIST: {
              intent_output_enabled: "true",
              intent_action: "com.example.ACTION",
              intent_delivery: "2"
            }
          }
        }
      }
    })
``` 