### PR TITLE
Custom intent

### DIFF
--- a/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedgePlugin.java
+++ b/android/src/main/java/com/jkbz/capacitor/datawedge/DataWedgePlugin.java
@@ -120,7 +120,7 @@ public class DataWedgePlugin extends Plugin {
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
 
-            if (!action.equals(this.scanIntent)) return;
+            if (!action.equals(scanIntent)) return;
 
             try {
                 String data = intent.getStringExtra("com.symbol.datawedge.data_string");

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@capacitor/android": "^5.0.0",


### PR DESCRIPTION
I just fixed the scanIntent reference issue. Because `this.scanIntent` refers to `BroadcastReceiver` and not the `DataWedgePlugin` Class. And I also added `"prepare": "npm run build"` to build that package so you can install it directly from GitHub. This will create the dist files.